### PR TITLE
修复了run.py中可能因为successful_analysis_pp.txt未创建引发的崩溃，加强了code_inspection部分…

### DIFF
--- a/Privacy-compliance-detection-2.1/core/src/main/java/android/findMultipleAPKIoTDataPoints.java
+++ b/Privacy-compliance-detection-2.1/core/src/main/java/android/findMultipleAPKIoTDataPoints.java
@@ -1,27 +1,23 @@
 package android;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.xmlpull.v1.XmlPullParserException;
 import soot.*;
 import soot.jimple.InvokeExpr;
 import soot.jimple.Stmt;
 import soot.jimple.StringConstant;
 import soot.jimple.infoflow.android.manifest.ProcessManifest;
 import soot.options.Options;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
+
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import org.xmlpull.v1.XmlPullParserException;
+import java.util.concurrent.*;
 
 public class findMultipleAPKIoTDataPoints {
     public static String logsPath = "";
@@ -393,9 +389,11 @@ public class findMultipleAPKIoTDataPoints {
                                 boolean isPrivacyItem = false;
                                 for (String s : privacyItemList) {
                                     // if (tmp.contains(s)) {
-                                    // 判断策略为 编辑距离相似度 > 0.75 || 以隐私数据项开头 || 以隐私数据项结尾
-                                    if (getEditDistanceSimilarity(tmp, s) > 0.75 || tmp.startsWith(s)
-                                            || tmp.endsWith(s)) {
+                                    // 判断策略为 编辑距离相似度 > 0.75 || 以隐私数据项开头 || 以隐私数据项结尾,
+                                    // 但是要求数据项的长度不能大于2倍的隐私数据项目长度
+                                    // 用来避免类似password save action, password save open dialog的误报
+                                    if ((getEditDistanceSimilarity(tmp, s) > 0.75 || tmp.startsWith(s)
+                                            || tmp.endsWith(s)) && tmp.length() < 2 * s.length()) {
                                         isPrivacyItem = true;
                                         break;
                                     }

--- a/run.py
+++ b/run.py
@@ -393,10 +393,14 @@ def get_privacy_policy(os_type, config_settings, cur_path, total_apk, log_folder
         cnt_pp_num = 0
         # 此时需要读取successful_analysis_pp.txt的记录,看哪些是成功请求到了的URL,这里就不再分析
         # 但是没有请求成功的,这里还要继续尝试
-        with open(os.path.join(cur_path, 'AppUIAutomator2Navigation', 'successful_analysis_pp.txt'), 'r',
-                  encoding='utf-8') as f:
-            content = f.readlines()
-        successful_pp_set = set([item.rstrip('\n') for item in content])
+        # 由于存在运行时间过短的可能性，这时successful_analysis_pp.txt可能压根没有产生
+        try:
+            with open(os.path.join(cur_path, 'AppUIAutomator2Navigation', 'successful_analysis_pp.txt'), 'r',
+                      encoding='utf-8') as f:
+                content = f.readlines()
+            successful_pp_set = set([item.rstrip('\n') for item in content])
+        except FileNotFoundError:
+            successful_pp_set = set()
         for key, val in app_dict.items():
             # dirs = os.listdir('./AppUIAutomator2Navigation/collectData' + '/' + val)
             dirs = os.listdir(os.path.join(cur_path, 'AppUIAutomator2Navigation', 'collectData', val))


### PR DESCRIPTION
…对隐私数据项的要求，要求数据项长度不能大于两倍的字典数据项